### PR TITLE
Add pop() method to navigate one step back

### DIFF
--- a/Sources/CleanUI/Main/Classes/CUNavigation.swift
+++ b/Sources/CleanUI/Main/Classes/CUNavigation.swift
@@ -36,6 +36,14 @@ public class CUNavigation {
         }
     }
     
+    /// Trys to pop the current view to navigate one step back
+    /// - Parameter animated: Animated, default `true`
+    public static func pop(_ animated: Bool = true) {
+        if let navigationController = self.getCurrentNavigationController() {
+            navigationController.popViewController(animated: animated)
+        }
+    }
+    
     /// Trys to find the current active UINavigationController.
     /// - Returns: An optional UINavigationController
     public static func getCurrentNavigationController() -> UINavigationController? {


### PR DESCRIPTION
The popToRootView() method pops all views to the root controller. If you want to go back one step programmatically, you need to have a separate pop() method for that.